### PR TITLE
better handling of re-rendering the card

### DIFF
--- a/src/combined-card.ts
+++ b/src/combined-card.ts
@@ -160,6 +160,8 @@ class CombinedCard extends LitElement implements LovelaceCard {
     this._rebuildCard(cardElToReplace, config);
   }
 
+  // TODO is this a mistake? should we just re-render the card instead?
+  // I don't actually remember when this does execute
   private _rebuildCard(
     cardElToReplace: LovelaceCard,
     config: LovelaceCardConfig


### PR DESCRIPTION
The `helpers` control how we render the card, so really, they can count as state. Changing the `helpers` (which really only happens at load time) should re-render the card anyway.

This probably fixes the need for #3 